### PR TITLE
Configureのリファクタ

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -8,7 +8,7 @@ on:
     tags-ignore:
       - '**'
     paths:
-      - '*.js'
+      - '**.js'
 
 jobs:
   lint_and_test:

--- a/lib/common.js
+++ b/lib/common.js
@@ -4,6 +4,14 @@ function hasProperty(obj, key) {
     return obj && Object.hasOwnProperty.call(obj, key);
 }
 
+function hasTypeOfProperty(obj, key, type) {
+    return hasProperty(obj, key) && typeof obj[key] === type;
+}
+
+function getObjectValueFrom(obj, key, type, defaultValue) {
+    return hasTypeOfProperty(obj, key, type) ? obj[key] || defaultValue : defaultValue;
+}
+
 function stringLength(text) {
     if (typeof text !== 'string') {
         throw new Error('text is not string type.');
@@ -49,6 +57,8 @@ function stringSlice(text, start, end) {
 
 module.exports = {
     hasProperty,
+    hasTypeOfProperty,
+    getObjectValueFrom,
     stringLength,
     stringSlice,
 };

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -1,49 +1,64 @@
 'use strict';
 
-const { hasProperty } = require('./common');
+const { hasTypeOfProperty, getObjectValueFrom } = require('./common');
 
 const ANCHOR_LINK_CLASS_NAME = 'link-preview';
 const DESCRIPTION_LENGTH = 140;
 const DISGUISE_CRAWLER = true;
 
-module.exports = hexoCfg => {
-    const config = {
-        class_name: {
-            anchor_link: ANCHOR_LINK_CLASS_NAME,
-        },
+function getDefaultConfig() {
+    return {
+        class_name: { anchor_link: ANCHOR_LINK_CLASS_NAME },
         description_length: DESCRIPTION_LENGTH,
         disguise_crawler: DISGUISE_CRAWLER,
     };
+}
 
-    if (!hasProperty(hexoCfg, 'link_preview')) {
-        return config;
+function getClassNameObject(linkPreviewCfg, defaultValue) {
+    const classNameCfg = linkPreviewCfg.class_name;
+
+    const classNameObj = {
+        anchor_link: getAnchorLinkClassName(classNameCfg, defaultValue),
+    };
+
+    if (hasTypeOfProperty(classNameCfg, 'image', 'string') && classNameCfg.image !== '') {
+        classNameObj.image = classNameCfg.image;
     }
 
-    const hexoCfgLinkPreview = hexoCfg.link_preview;
+    return classNameObj;
+}
 
-    if (hasProperty(hexoCfgLinkPreview, 'class_name')) {
-        const hexoCfgLinkPreviewClassName = hexoCfgLinkPreview.class_name;
+function getAnchorLinkClassName(classNameCfg, defaultValue) {
+    switch (typeof classNameCfg) {
+        case 'object':
+            return getObjectValueFrom(classNameCfg, 'anchor_link', 'string', defaultValue);
+        case 'string':
+            return classNameCfg || defaultValue;
+    }
+    return defaultValue;
+}
 
-        if (typeof hexoCfgLinkPreviewClassName === 'string') {
-            config.class_name.anchor_link = hexoCfgLinkPreviewClassName || config.class_name.anchor_link;
-        } else if (typeof hexoCfgLinkPreviewClassName === 'object') {
-            if (hasProperty(hexoCfgLinkPreviewClassName, 'anchor_link') && typeof hexoCfgLinkPreviewClassName.anchor_link === 'string') {
-                config.class_name.anchor_link = hexoCfgLinkPreviewClassName.anchor_link || config.class_name.anchor_link;
-            }
+function getDescriptionLength(linkPreviewCfg, defaultValue) {
+    return getObjectValueFrom(linkPreviewCfg, 'description_length', 'number', defaultValue);
+}
 
-            if (hasProperty(hexoCfgLinkPreviewClassName, 'image') && hexoCfgLinkPreviewClassName.image !== '') {
-                config.class_name.image = hexoCfgLinkPreviewClassName.image;
-            }
-        }
+function getDisguiseCrawler(linkPreviewCfg, defaultValue) {
+    if (hasTypeOfProperty(linkPreviewCfg, 'disguise_crawler', 'boolean')) {
+        return linkPreviewCfg.disguise_crawler;
+    }
+    return defaultValue;
+}
+
+module.exports = hexoCfg => {
+    if (!hasTypeOfProperty(hexoCfg, 'link_preview', 'object')) {
+        return getDefaultConfig();
     }
 
-    if (hasProperty(hexoCfgLinkPreview, 'description_length') && typeof hexoCfgLinkPreview.description_length === 'number') {
-        config.description_length = hexoCfgLinkPreview.description_length || config.description_length;
-    }
+    const linkPreviewCfg = hexoCfg.link_preview;
 
-    if (hasProperty(hexoCfgLinkPreview, 'disguise_crawler') && typeof hexoCfgLinkPreview.disguise_crawler === 'boolean') {
-        config.disguise_crawler = hexoCfgLinkPreview.disguise_crawler;
-    }
-
-    return config;
+    return {
+        class_name: getClassNameObject(linkPreviewCfg, ANCHOR_LINK_CLASS_NAME),
+        description_length: getDescriptionLength(linkPreviewCfg, DESCRIPTION_LENGTH),
+        disguise_crawler: getDisguiseCrawler(linkPreviewCfg, DISGUISE_CRAWLER),
+    };
 };

--- a/test/configure.test.js
+++ b/test/configure.test.js
@@ -18,7 +18,7 @@ describe('configure', () => {
     it('Specify all values', () => {
         const hexoCfg = {
             link_preview: {
-                class_name: { anchor_link: 'link-preview', image: 'not-gallery-item' },
+                class_name: { anchor_link: 'link-preview-2', image: 'not-gallery-item' },
                 description_length: 100,
                 disguise_crawler: false,
             },
@@ -26,7 +26,7 @@ describe('configure', () => {
 
         expect(getConfig(hexoCfg)).toEqual(
             {
-                class_name: { anchor_link: 'link-preview', image: 'not-gallery-item' },
+                class_name: { anchor_link: 'link-preview-2', image: 'not-gallery-item' },
                 description_length: 100,
                 disguise_crawler: false,
             }
@@ -36,13 +36,13 @@ describe('configure', () => {
     it('Specify a valid string value at class_name', () => {
         const hexoCfg = {
             link_preview: {
-                class_name: 'link-preview',
+                class_name: 'link-preview-2',
             },
         };
 
         expect(getConfig(hexoCfg)).toEqual(
             {
-                class_name: { anchor_link: 'link-preview' },
+                class_name: { anchor_link: 'link-preview-2' },
                 description_length: 140,
                 disguise_crawler: true,
             }
@@ -68,14 +68,14 @@ describe('configure', () => {
     it('Specify a object which has valid anchor_link only at class_name', () => {
         const hexoCfg = {
             link_preview: {
-                class_name: { anchor_link: 'link-preview' },
+                class_name: { anchor_link: 'link-preview-2' },
             },
         };
 
         expect(getConfig(hexoCfg)).toEqual(
             {
                 class_name: {
-                    anchor_link: 'link-preview',
+                    anchor_link: 'link-preview-2',
                 },
                 description_length: 140,
                 disguise_crawler: true,


### PR DESCRIPTION
### Description

- Refactor a code of the `configure` for maintainability.
- Add some methods which object operate to the `common`.
- Fix a paths event trigger of the `Lint and Test` workflow.

### Relations

Nothing

### References

[configure.js issues @ codeclimate](https://codeclimate.com/github/h-sugawara/hexo-tag-ogp-link-preview/lib/configure.js/source#issue-f28c1845cb5d122465fff4f336ed0d26)

### Others

Nothing