### PR TITLE
Commonのリファクタ

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -12,53 +12,13 @@ function getObjectValueFrom(obj, key, type, defaultValue) {
     return hasTypeOfProperty(obj, key, type) ? obj[key] || defaultValue : defaultValue;
 }
 
-function stringLength(text) {
-    if (typeof text !== 'string') {
-        throw new Error('text is not string type.');
-    }
-
-    const segmentation = new Intl.Segmenter('ja', { granularity: 'grapheme' });
-    return [...segmentation.segment(text)].length;
-}
-
-function stringSlice(text, start, end) {
-    if (typeof text !== 'string') {
-        throw new Error('text is not string type.');
-    }
-
-    const strLength = stringLength(text);
-
-    let startIndex = typeof start !== 'number' || isNaN(Number(start)) ? 0 : Number(start);
-    if (startIndex < 0) {
-        startIndex = Math.max(startIndex + strLength, 0);
-    }
-
-    let endIndex = typeof end !== 'number' || isNaN(Number(end)) ? strLength : Number(end);
-    if (endIndex >= strLength) {
-        endIndex = strLength;
-    } else if (endIndex < 0) {
-        endIndex = Math.max(endIndex + strLength, 0);
-    }
-
-    let strings = '';
-
-    if (startIndex >= strLength || endIndex <= startIndex) {
-        return strings;
-    }
-    const segmentation = new Intl.Segmenter('ja', { granularity: 'grapheme' });
-    [...segmentation.segment(text)]
-        .forEach((value, index) => {
-            if (startIndex <= index && index < endIndex) {
-                strings += value.segment;
-            }
-        });
-    return strings;
+function getValidNumber(value, defaultValue) {
+    return typeof value !== 'number' || isNaN(Number(value)) ? defaultValue : Number(value);
 }
 
 module.exports = {
     hasProperty,
     hasTypeOfProperty,
     getObjectValueFrom,
-    stringLength,
-    stringSlice,
+    getValidNumber,
 };

--- a/lib/opengraph.js
+++ b/lib/opengraph.js
@@ -1,38 +1,29 @@
 'use strict';
 
 const util = require('hexo-util');
-const { hasProperty, stringLength, stringSlice } = require('./common');
+const { hasProperty, hasTypeOfProperty, getObjectValueFrom } = require('./common');
+const { stringLength, stringSlice } = require('./strings');
 
 function getOgTitle(ogp) {
-    const result = { valid: false, title: '' };
-
-    if (!hasProperty(ogp, 'ogTitle')) {
-        return result;
+    if (!hasTypeOfProperty(ogp, 'ogTitle', 'string')) {
+        return { valid: false, title: '' };
     }
 
     const escapedTitle = util.escapeHTML(ogp.ogTitle);
-    if (typeof escapedTitle === 'string' && escapedTitle !== '') {
-        result.valid = true;
-        result.title = escapedTitle;
-    }
-    return result;
+
+    return { valid: escapedTitle !== '', title: escapedTitle };
 }
 
 function getOgDescription(ogp, maxLength) {
-    const result = { valid: false, description: '' };
-
-    if (!hasProperty(ogp, 'ogDescription')) {
-        return result;
+    if (!hasTypeOfProperty(ogp, 'ogDescription', 'string')) {
+        return { valid: false, description: '' };
     }
 
     const escapedDescription = util.escapeHTML(ogp.ogDescription);
     const descriptionText = maxLength && stringLength(escapedDescription) > maxLength
         ? stringSlice(escapedDescription, 0, maxLength) + '...' : escapedDescription;
-    if (typeof descriptionText === 'string' && descriptionText !== '') {
-        result.valid = true;
-        result.description = descriptionText;
-    }
-    return result;
+
+    return { valid: descriptionText !== '', description: descriptionText };
 }
 
 function getOgImage(ogp, selectIndex = 0) {
@@ -41,8 +32,9 @@ function getOgImage(ogp, selectIndex = 0) {
     }
 
     const index = selectIndex >= ogp.ogImage.length ? ogp.ogImage.length - 1 : 0;
+    const imageUrl = getObjectValueFrom(ogp.ogImage[index], 'url', 'string', '');
 
-    return { valid: true, image: ogp.ogImage[index].url };
+    return { valid: imageUrl !== '', image: imageUrl };
 }
 
 module.exports = {

--- a/lib/strings.js
+++ b/lib/strings.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const { getValidNumber } = require('./common');
+
+function stringLength(text) {
+    if (typeof text !== 'string') {
+        throw new Error('text is not string type.');
+    }
+
+    const segmentation = new Intl.Segmenter('ja', { granularity: 'grapheme' });
+    return [...segmentation.segment(text)].length;
+}
+
+function getStartIndex(start, strLength) {
+    const startIndex = getValidNumber(start, 0);
+    return startIndex < 0 ? Math.max(startIndex + strLength, 0) : startIndex;
+}
+
+function getEndIndex(end, strLength) {
+    const endIndex = getValidNumber(end, strLength);
+    if (endIndex >= strLength) {
+        return strLength;
+    }
+    return endIndex < 0 ? Math.max(endIndex + strLength, 0) : endIndex;
+}
+
+function stringSlice(text, start, end) {
+    if (typeof text !== 'string') {
+        throw new Error('text is not string type.');
+    }
+
+    const strLength = stringLength(text);
+    const startIndex = getStartIndex(start, strLength);
+    const endIndex = getEndIndex(end, strLength);
+
+    let strings = '';
+
+    if (startIndex >= strLength || endIndex <= startIndex) {
+        return strings;
+    }
+    const segmentation = new Intl.Segmenter('ja', { granularity: 'grapheme' });
+    [...segmentation.segment(text)]
+        .forEach((value, index) => {
+            if (startIndex <= index && index < endIndex) {
+                strings += value.segment;
+            }
+        });
+    return strings;
+}
+
+module.exports = {
+    stringLength,
+    stringSlice,
+};

--- a/test/common.test.js
+++ b/test/common.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { hasProperty, stringLength, stringSlice } = require('../lib/common');
+const { hasProperty, hasTypeOfProperty, getObjectValueFrom, getValidNumber } = require('../lib/common');
 
 describe('common', () => {
     it('Has a property at object', () => {
@@ -15,39 +15,35 @@ describe('common', () => {
         expect(hasProperty(obj, 'not_test_key')).toBeFalsy();
     });
 
-    it('Calculate a length of string', () => {
-        expect(stringLength('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎')).toEqual(14);
+    it('Has a property at object which string type', () => {
+        const obj = { 'test_key': 'test_value' };
+
+        expect(hasTypeOfProperty(obj, 'test_key', 'string')).toBeTruthy();
     });
 
-    it('Cannot calculate a length of except for string', () => {
-        expect(() => stringLength(0)).toThrow(new Error('text is not string type.'));
+    it('Has a property at object which except for string type', () => {
+        const obj = { 'test_key': 1234 };
+
+        expect(hasTypeOfProperty(obj, 'test_key', 'string')).toBeFalsy();
     });
 
-    it('Slice a string', () => {
-        expect(stringSlice('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎', 0, 3)).toEqual('aBあ');
+    it('Get a value of property at object which string type successfully', () => {
+        const obj = { 'test_key': 'test_value' };
+
+        expect(getObjectValueFrom(obj, 'test_key', 'string', 'default_value')).toEqual('test_value');
     });
 
-    it('Cannot slice a value except for string', () => {
-        expect(() => stringSlice(0)).toThrow(new Error('text is not string type.'));
+    it('Get a default value which specified because fail to get a value of object property', () => {
+        const obj = { 'test_key': 1234 };
+
+        expect(getObjectValueFrom(obj, 'test_key', 'string', 'default_value')).toEqual('default_value');
     });
 
-    it('Slice a string (start is not number type)', () => {
-        expect(stringSlice('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎', 'hoge', 5)).toEqual('aBあア亞');
+    it('Get a valid number from specified value successfully', () => {
+        expect(getValidNumber(1234, 9876)).toEqual(1234);
     });
 
-    it('Slice a string (start is smaller than zero)', () => {
-        expect(stringSlice('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎', -5, 13)).toEqual('%+👨🏻‍💻🇯🇵');
-    });
-
-    it('Slice a string (end calculate automatically)', () => {
-        expect(stringSlice('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎', 7)).toEqual('19%+👨🏻‍💻🇯🇵🍎');
-    });
-
-    it('Slice a string (end is smaller than zero)', () => {
-        expect(stringSlice('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎', 7, -4)).toEqual('19%');
-    });
-
-    it('Slice a string (end is smaller than start)', () => {
-        expect(stringSlice('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎', -1, -2)).toEqual('');
+    it('Get a default number which specified because value is not valid number', () => {
+        expect(getValidNumber('test_value', 9876)).toEqual(9876);
     });
 });

--- a/test/opengraph.test.js
+++ b/test/opengraph.test.js
@@ -4,110 +4,98 @@ const { getOgTitle, getOgDescription, getOgImage } = require('../lib/opengraph')
 
 describe('opengraph', () => {
     it('Has a valid value at OpenGraphTitle', () => {
-        const ogp = {
-            'ogTitle': 'test_title',
-        };
+        const ogp = { 'ogTitle': 'test_title' };
 
-        expect(getOgTitle(ogp)).toEqual(
-            { valid: true, title: 'test_title' }
-        );
+        expect(getOgTitle(ogp)).toEqual({ valid: true, title: 'test_title' });
     });
 
     it('Not contains a value of OpenGraphTitle', () => {
         const ogp = {};
 
-        expect(getOgTitle(ogp)).toEqual(
-            { valid: false, title: '' }
-        );
+        expect(getOgTitle(ogp)).toEqual({ valid: false, title: '' });
+    });
+
+    it('Has a empty value at OpenGraphTitle', () => {
+        const ogp = { 'ogTitle': '' };
+
+        expect(getOgTitle(ogp)).toEqual({ valid: false, title: '' });
     });
 
     it('Has a invalid value at OpenGraphTitle', () => {
-        const ogp = {
-            'ogTitle': '',
-        };
+        const ogp = { 'ogTitle': 1000 };
 
-        expect(getOgTitle(ogp)).toEqual(
-            { valid: false, title: '' }
-        );
+        expect(getOgTitle(ogp)).toEqual({ valid: false, title: '' });
     });
 
     it('Has a valid value at OpenGraphDescription', () => {
-        const ogp = {
-            'ogDescription': 'test_description',
-        };
+        const ogp = { 'ogDescription': 'test_description' };
 
-        expect(getOgDescription(ogp, 140)).toEqual(
-            { valid: true, description: 'test_description' }
-        );
+        expect(getOgDescription(ogp, 140)).toEqual({ valid: true, description: 'test_description' });
     });
 
     it('Has a valid english sentence which is over max length at OpenGraphDescription', () => {
-        const ogp = {
-            'ogDescription': 'test_description',
-        };
+        const ogp = { 'ogDescription': 'test_description' };
 
-        expect(getOgDescription(ogp, 4)).toEqual(
-            { valid: true, description: 'test...' }
-        );
+        expect(getOgDescription(ogp, 4)).toEqual({ valid: true, description: 'test...' });
     });
 
     it('Has a valid japanese sentence which is over max length at OpenGraphDescription', () => {
-        const ogp = {
-            'ogDescription': '👨🏻‍💻󠁧󠁢󠁥󠁮󠁧󠁿テストの🇯🇵ですくりぷしょん🍎を書きました。',
-        };
+        const ogp = { 'ogDescription': '👨🏻‍💻󠁧󠁢󠁥󠁮󠁧󠁿テストの🇯🇵ですくりぷしょん🍎を書きました。' };
 
-        expect(getOgDescription(ogp, 15)).toEqual(
-            { valid: true, description: '👨🏻‍💻󠁧󠁢󠁥󠁮󠁧󠁿テストの🇯🇵ですくりぷしょん🍎...' }
-        );
+        expect(getOgDescription(ogp, 15)).toEqual({ valid: true, description: '👨🏻‍💻󠁧󠁢󠁥󠁮󠁧󠁿テストの🇯🇵ですくりぷしょん🍎...' });
     });
 
     it('Not contains a value of OpenGraphDescription', () => {
         const ogp = {};
 
-        expect(getOgDescription(ogp, 140)).toEqual(
-            { valid: false, description: '' }
-        );
+        expect(getOgDescription(ogp, 140)).toEqual({ valid: false, description: '' });
+    });
+
+    it('Has a empty value at OpenGraphDescription', () => {
+        const ogp = { 'ogDescription': '' };
+
+        expect(getOgDescription(ogp, 140)).toEqual({ valid: false, description: '' });
     });
 
     it('Has a invalid value at OpenGraphDescription', () => {
-        const ogp = {
-            'ogDescription': '',
-        };
+        const ogp = { 'ogDescription': 1234 };
 
-        expect(getOgDescription(ogp, 140)).toEqual(
-            { valid: false, description: '' }
-        );
+        expect(getOgDescription(ogp, 140)).toEqual({ valid: false, description: '' });
     });
 
     it('Has a value at OpenGraphImage', () => {
-        const ogp = {
-            'ogImage': [
-                { url: 'test.png' },
-            ],
-        };
+        const ogp = { 'ogImage': [{ url: 'test.png' }]};
 
-        expect(getOgImage(ogp)).toEqual(
-            { valid: true, image: 'test.png' }
-        );
+        expect(getOgImage(ogp)).toEqual({ valid: true, image: 'test.png' });
+    });
+
+    it('Has a empty value at OpenGraphImage', () => {
+        const ogp = { 'ogImage': [{ url: '' }]};
+
+        expect(getOgImage(ogp)).toEqual({ valid: false, image: '' });
+    });
+
+    it('Has a invalid value at OpenGraphImage', () => {
+        const ogp = { 'ogImage': [{ url: 1234 }]};
+
+        expect(getOgImage(ogp)).toEqual({ valid: false, image: '' });
     });
 
     it('Has a value at OpenGraphImage (selectIndex is larger than length)', () => {
-        const ogp = {
-            'ogImage': [
-                { url: 'test.png' },
-            ],
-        };
+        const ogp = { 'ogImage': [{ url: 'test.png' }]};
 
-        expect(getOgImage(ogp, 2)).toEqual(
-            { valid: true, image: 'test.png' }
-        );
+        expect(getOgImage(ogp, 2)).toEqual({ valid: true, image: 'test.png' });
     });
 
     it('Not contains a value of OpenGraphImage', () => {
         const ogp = {};
 
-        expect(getOgImage(ogp)).toEqual(
-            { valid: false, image: '' }
-        );
+        expect(getOgImage(ogp)).toEqual({ valid: false, image: '' });
+    });
+
+    it('Not contains a url value in OpenGraphImage', () => {
+        const ogp = { 'ogImage': [{ width: 1200 }]};
+
+        expect(getOgImage(ogp)).toEqual({ valid: false, image: '' });
     });
 });

--- a/test/strings.test.js
+++ b/test/strings.test.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const { stringLength, stringSlice } = require('../lib/strings');
+
+describe('common', () => {
+    it('Calculate a length of string', () => {
+        expect(stringLength('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎')).toEqual(14);
+    });
+
+    it('Cannot calculate a length of except for string', () => {
+        expect(() => stringLength(0)).toThrow(new Error('text is not string type.'));
+    });
+
+    it('Slice a string', () => {
+        expect(stringSlice('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎', 0, 3)).toEqual('aBあ');
+    });
+
+    it('Cannot slice a value except for string', () => {
+        expect(() => stringSlice(0)).toThrow(new Error('text is not string type.'));
+    });
+
+    it('Slice a string (start is not number type)', () => {
+        expect(stringSlice('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎', 'hoge', 5)).toEqual('aBあア亞');
+    });
+
+    it('Slice a string (start is smaller than zero)', () => {
+        expect(stringSlice('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎', -5, 13)).toEqual('%+👨🏻‍💻🇯🇵');
+    });
+
+    it('Slice a string (end calculate automatically)', () => {
+        expect(stringSlice('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎', 7)).toEqual('19%+👨🏻‍💻🇯🇵🍎');
+    });
+
+    it('Slice a string (end is smaller than zero)', () => {
+        expect(stringSlice('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎', 7, -4)).toEqual('19%');
+    });
+
+    it('Slice a string (end is smaller than start)', () => {
+        expect(stringSlice('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎', -1, -2)).toEqual('');
+    });
+});


### PR DESCRIPTION
### Description

- Remove all string operate methods form `common`.
- Create some methods which string operate at `strings`.
- Refactor a `common` test.
- Add a `strings` test.
- Add `getValidNumber` method at `common`.
- Refactor all methods of `opengraph`.

### Relations

Nothing

### References

[issues of common.js @ codeclimate](https://codeclimate.com/github/h-sugawara/hexo-tag-ogp-link-preview/lib/common.js/source#issue-8024522af2a657c673a5f03c0deebcde)

### Others

Nothing