### PR TITLE
Fixed OGP acquisition failure due to Content Negotiation

### DIFF
--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -33,7 +33,9 @@ function findOptionalArgs(opts, find) {
 
 function getFetchOptions(isCrawler) {
     const fetchOptions = {};
-    const headers = {};
+    const headers = {
+        'accept': 'text/html',
+    };
 
     if (typeof isCrawler === 'boolean' && isCrawler) {
         headers['user-agent'] = CRAWLER_USER_AGENT;

--- a/test/parameters.test.js
+++ b/test/parameters.test.js
@@ -15,6 +15,7 @@ describe('parameters', () => {
                     url: args[0],
                     fetchOptions: {
                         headers: {
+                            'accept': 'text/html',
                             'user-agent': 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Chrome/112.0.0.0 Safari/537.36',
                         },
                     },
@@ -43,6 +44,7 @@ describe('parameters', () => {
                     url: args[0],
                     fetchOptions: {
                         headers: {
+                            'accept': 'text/html',
                             'user-agent': 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Chrome/112.0.0.0 Safari/537.36',
                         },
                     },
@@ -60,7 +62,7 @@ describe('parameters', () => {
 
         expect(getParameters(args, fallbackText, config)).toEqual(
             {
-                scrape: { url: args[0], fetchOptions: {} },
+                scrape: { url: args[0], fetchOptions: { headers: { accept: 'text/html' } } },
                 generate: { target: '_blank', rel: 'nofollow', loading: 'lazy', descriptionLength, className, fallbackText },
             }
         );


### PR DESCRIPTION
### Description

I applied the problem fixed in https://github.com/jshemas/openGraphScraper/pull/204 to this library.

As shown in the link above, before the fix, `open-graph-scraper` had a problem where OGP could not be obtained because the header required by some URLs was missing.

When `disguise_crawler` is set to `false`, upstream fixes are automatically applied with no problem, but when `true` this tool's `fetchOptions` override those of upstream, whichwhich still causes problems.

Fixed this issue by ensuring that `hexo-tag-ogp-link-preview` adds the `accept` header even when explicitly specifying `fetchOptions` to `open-graph-scraper`.

### Relations

### References

https://developer.mozilla.org/docs/Web/HTTP/Content_negotiation

### Others
