### PR TITLE
画像エレメントの代替テキストを空にする

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -3,27 +3,38 @@
 const { newHtmlDivTag, newHtmlAnchorTag, newHtmlImgTag } = require('./htmltag');
 const { getOgTitle, getOgDescription, getOgImage } = require('./opengraph');
 
+function newContent(escapedTitle, escapedDesc, ogImage, generate) {
+    const content = [];
+
+    if (ogImage.valid) {
+        content.push(newHtmlDivTag('og-image', newHtmlImgTag(ogImage.image, '', generate)));
+    }
+
+    const descriptions = [
+        newHtmlDivTag('og-title', escapedTitle),
+        newHtmlDivTag('og-description', escapedDesc),
+    ];
+    content.push(newHtmlDivTag('descriptions', descriptions.join('')));
+
+    return content.join('');
+}
+
 module.exports = (scraper, params) => {
     return scraper(params.scrape)
         .then((data) => data.result)
         .then((ogp) => {
-            const { valid: isTitleValid, title: escapedTitle } = getOgTitle(ogp);
-            const { valid: isDescValid, description: escapedDesc } = getOgDescription(ogp, params.generate.descriptionLength);
-            const { valid: isImageValid, image: imageUrl } = getOgImage(ogp);
+            const { valid: isTitleValid, title } = getOgTitle(ogp);
+            const { valid: isDescValid, description } = getOgDescription(ogp, params.generate.descriptionLength);
 
             if (!isTitleValid || !isDescValid) {
                 return newHtmlAnchorTag(params.scrape.url, params.generate);
             }
 
-            const title = newHtmlDivTag('og-title', escapedTitle);
-            const desc = newHtmlDivTag('og-description', escapedDesc);
-            const descriptions = newHtmlDivTag('descriptions', title + desc);
-            const image = isImageValid
-                ? newHtmlDivTag('og-image', newHtmlImgTag(imageUrl, escapedTitle, params.generate))
-                : '';
-            const content = image + descriptions;
-
-            return newHtmlAnchorTag(params.scrape.url, params.generate, content);
+            return newHtmlAnchorTag(
+                params.scrape.url,
+                params.generate,
+                newContent(title, description, getOgImage(ogp), params.generate)
+            );
         })
         .catch((error) => {
             throw error;

--- a/test/generator.test.js
+++ b/test/generator.test.js
@@ -28,7 +28,7 @@ describe('generator', () => {
                 params.generate,
                 newHtmlDivTag(
                     'og-image',
-                    newHtmlImgTag(imageUrl, title, params.generate)
+                    newHtmlImgTag(imageUrl, '', params.generate)
                 )
                 + newHtmlDivTag(
                     'descriptions',


### PR DESCRIPTION
### Description

make alt attribute of the image element empty text.

### Relations



### References



### Others
