### PR TITLE
open-graph-scraperでエラーが発生した時にフォールバックテキストリンクにする

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -37,6 +37,8 @@ module.exports = (scraper, params) => {
             );
         })
         .catch((error) => {
-            throw error;
+            console.error('scraping error:', error);
+
+            return newHtmlAnchorTag(params.scrape.url, params.generate);
         });
 };

--- a/test/common.test.js
+++ b/test/common.test.js
@@ -4,46 +4,34 @@ const { hasProperty, hasTypeOfProperty, getObjectValueFrom, getValidNumber } = r
 
 describe('common', () => {
     it('Has a property at object', () => {
-        const obj = { test_key: 'test_value' };
-
-        expect(hasProperty(obj, 'test_key')).toBeTruthy();
+        expect(hasProperty({ test_key: 'test_value' }, 'test_key')).toBeTruthy();
     });
 
     it('Has not a property at object', () => {
-        const obj = { test_key: 'test_value' };
-
-        expect(hasProperty(obj, 'not_test_key')).toBeFalsy();
+        expect(hasProperty({ test_key: 'test_value' }, 'not_test_key')).toBeFalsy();
     });
 
     it('Has a property at object which string type', () => {
-        const obj = { test_key: 'test_value' };
-
-        expect(hasTypeOfProperty(obj, 'test_key', 'string')).toBeTruthy();
+        expect(hasTypeOfProperty({ test_key: 'test_value' }, 'test_key', 'string')).toBeTruthy();
     });
 
     it('Has a property at object which except for string type', () => {
-        const obj = { test_key: 1234 };
-
-        expect(hasTypeOfProperty(obj, 'test_key', 'string')).toBeFalsy();
+        expect(hasTypeOfProperty({ test_key: 1234 }, 'test_key', 'string')).toBeFalsy();
     });
 
     it('Get a value of property at object which string type successfully', () => {
-        const obj = { test_key: 'test_value' };
-
-        expect(getObjectValueFrom(obj, 'test_key', 'string', 'default_value')).toEqual('test_value');
+        expect(getObjectValueFrom({ test_key: 'test_value' }, 'test_key', 'string', 'default_value')).toStrictEqual('test_value');
     });
 
     it('Get a default value which specified because fail to get a value of object property', () => {
-        const obj = { test_key: 1234 };
-
-        expect(getObjectValueFrom(obj, 'test_key', 'string', 'default_value')).toEqual('default_value');
+        expect(getObjectValueFrom({ test_key: 1234 }, 'test_key', 'string', 'default_value')).toStrictEqual('default_value');
     });
 
     it('Get a valid number from specified value successfully', () => {
-        expect(getValidNumber(1234, 9876)).toEqual(1234);
+        expect(getValidNumber(1234, 9876)).toStrictEqual(1234);
     });
 
     it('Get a default number which specified because value is not valid number', () => {
-        expect(getValidNumber('test_value', 9876)).toEqual(9876);
+        expect(getValidNumber('test_value', 9876)).toStrictEqual(9876);
     });
 });

--- a/test/configure.test.js
+++ b/test/configure.test.js
@@ -6,13 +6,11 @@ describe('configure', () => {
     it('Nothing specified values', () => {
         const hexoCfg = {};
 
-        expect(getConfig(hexoCfg)).toEqual(
-            {
-                class_name: { anchor_link: 'link-preview' },
-                description_length: 140,
-                disguise_crawler: true,
-            }
-        );
+        expect(getConfig(hexoCfg)).toStrictEqual({
+            class_name: { anchor_link: 'link-preview' },
+            description_length: 140,
+            disguise_crawler: true,
+        });
     });
 
     it('Specify all values', () => {
@@ -24,13 +22,11 @@ describe('configure', () => {
             },
         };
 
-        expect(getConfig(hexoCfg)).toEqual(
-            {
-                class_name: { anchor_link: 'link-preview-2', image: 'not-gallery-item' },
-                description_length: 100,
-                disguise_crawler: false,
-            }
-        );
+        expect(getConfig(hexoCfg)).toStrictEqual({
+            class_name: { anchor_link: 'link-preview-2', image: 'not-gallery-item' },
+            description_length: 100,
+            disguise_crawler: false,
+        });
     });
 
     it('Specify a valid string value at class_name', () => {
@@ -40,13 +36,11 @@ describe('configure', () => {
             },
         };
 
-        expect(getConfig(hexoCfg)).toEqual(
-            {
-                class_name: { anchor_link: 'link-preview-2' },
-                description_length: 140,
-                disguise_crawler: true,
-            }
-        );
+        expect(getConfig(hexoCfg)).toStrictEqual({
+            class_name: { anchor_link: 'link-preview-2' },
+            description_length: 140,
+            disguise_crawler: true,
+        });
     });
 
     it('Specify a invalid string value at class_name', () => {
@@ -56,13 +50,11 @@ describe('configure', () => {
             },
         };
 
-        expect(getConfig(hexoCfg)).toEqual(
-            {
-                class_name: { anchor_link: 'link-preview' },
-                description_length: 140,
-                disguise_crawler: true,
-            }
-        );
+        expect(getConfig(hexoCfg)).toStrictEqual({
+            class_name: { anchor_link: 'link-preview' },
+            description_length: 140,
+            disguise_crawler: true,
+        });
     });
 
     it('Specify a object which has valid anchor_link only at class_name', () => {
@@ -72,15 +64,13 @@ describe('configure', () => {
             },
         };
 
-        expect(getConfig(hexoCfg)).toEqual(
-            {
-                class_name: {
-                    anchor_link: 'link-preview-2',
-                },
-                description_length: 140,
-                disguise_crawler: true,
-            }
-        );
+        expect(getConfig(hexoCfg)).toStrictEqual({
+            class_name: {
+                anchor_link: 'link-preview-2',
+            },
+            description_length: 140,
+            disguise_crawler: true,
+        });
     });
 
     it('Specify a object which has invalid anchor_link only at class_name', () => {
@@ -90,15 +80,13 @@ describe('configure', () => {
             },
         };
 
-        expect(getConfig(hexoCfg)).toEqual(
-            {
-                class_name: {
-                    anchor_link: 'link-preview',
-                },
-                description_length: 140,
-                disguise_crawler: true,
-            }
-        );
+        expect(getConfig(hexoCfg)).toStrictEqual({
+            class_name: {
+                anchor_link: 'link-preview',
+            },
+            description_length: 140,
+            disguise_crawler: true,
+        });
     });
 
     it('Specify a object which has image only at class_name', () => {
@@ -108,13 +96,11 @@ describe('configure', () => {
             },
         };
 
-        expect(getConfig(hexoCfg)).toEqual(
-            {
-                class_name: { anchor_link: 'link-preview', image: 'not-gallery-item' },
-                description_length: 140,
-                disguise_crawler: true,
-            }
-        );
+        expect(getConfig(hexoCfg)).toStrictEqual({
+            class_name: { anchor_link: 'link-preview', image: 'not-gallery-item' },
+            description_length: 140,
+            disguise_crawler: true,
+        });
     });
 
     it('Specify a something except for string or object at class_name', () => {
@@ -124,13 +110,11 @@ describe('configure', () => {
             },
         };
 
-        expect(getConfig(hexoCfg)).toEqual(
-            {
-                class_name: { anchor_link: 'link-preview' },
-                description_length: 140,
-                disguise_crawler: true,
-            }
-        );
+        expect(getConfig(hexoCfg)).toStrictEqual({
+            class_name: { anchor_link: 'link-preview' },
+            description_length: 140,
+            disguise_crawler: true,
+        });
     });
 
     it('Specify a invalid number value at description_length', () => {
@@ -140,12 +124,10 @@ describe('configure', () => {
             },
         };
 
-        expect(getConfig(hexoCfg)).toEqual(
-            {
-                class_name: { anchor_link: 'link-preview' },
-                description_length: 140,
-                disguise_crawler: true,
-            }
-        );
+        expect(getConfig(hexoCfg)).toEqual({
+            class_name: { anchor_link: 'link-preview' },
+            description_length: 140,
+            disguise_crawler: true,
+        });
     });
 });

--- a/test/generator.test.js
+++ b/test/generator.test.js
@@ -22,21 +22,15 @@ describe('generator', () => {
             })
         );
 
-        await expect(generate(scraper, params)).resolves.toEqual(
-            newHtmlAnchorTag(
-                params.scrape.url,
-                params.generate,
-                newHtmlDivTag(
-                    'og-image',
-                    newHtmlImgTag(imageUrl, '', params.generate)
-                )
-                + newHtmlDivTag(
-                    'descriptions',
-                    newHtmlDivTag('og-title', title)
-                    + newHtmlDivTag('og-description', description)
-                )
+        await expect(generate(scraper, params)).resolves.toStrictEqual(newHtmlAnchorTag(
+            params.scrape.url,
+            params.generate,
+            newHtmlDivTag('og-image', newHtmlImgTag(imageUrl, '', params.generate))
+            + newHtmlDivTag(
+                'descriptions',
+                newHtmlDivTag('og-title', title) + newHtmlDivTag('og-description', description)
             )
-        );
+        ));
     });
 
     it('Was able to get title and description from OpenGraph', async () => {
@@ -53,17 +47,14 @@ describe('generator', () => {
             })
         );
 
-        await expect(generate(scraper, params)).resolves.toEqual(
-            newHtmlAnchorTag(
-                params.scrape.url,
-                params.generate,
-                newHtmlDivTag(
-                    'descriptions',
-                    newHtmlDivTag('og-title', title)
-                    + newHtmlDivTag('og-description', description)
-                )
+        await expect(generate(scraper, params)).resolves.toEqual(newHtmlAnchorTag(
+            params.scrape.url,
+            params.generate,
+            newHtmlDivTag(
+                'descriptions',
+                newHtmlDivTag('og-title', title) + newHtmlDivTag('og-description', description)
             )
-        );
+        ));
     });
 
     it('Neither able to get title nor description from OpenGraph', async () => {
@@ -80,7 +71,7 @@ describe('generator', () => {
             })
         );
 
-        await expect(generate(scraper, params)).resolves.toEqual(
+        await expect(generate(scraper, params)).resolves.toStrictEqual(
             newHtmlAnchorTag(params.scrape.url, params.generate)
         );
     });

--- a/test/generator.test.js
+++ b/test/generator.test.js
@@ -99,8 +99,8 @@ describe('generator', () => {
             })
         );
 
-        await expect(generate(scraper, params)).rejects.toThrow(
-            new Error('error from mock OpenGraph scraper.')
+        await expect(generate(scraper, params)).resolves.toStrictEqual(
+            newHtmlAnchorTag(params.scrape.url, params.generate)
         );
     });
 });

--- a/test/htmltag.test.js
+++ b/test/htmltag.test.js
@@ -4,7 +4,7 @@ const { newHtmlDivTag, newHtmlAnchorTag, newHtmlImgTag } = require('../lib/htmlt
 
 describe('htmlTag', () => {
     it('Generate a new html div tag', () => {
-        expect(newHtmlDivTag('div-class', 'text')).toEqual(
+        expect(newHtmlDivTag('div-class', 'text')).toStrictEqual(
             '<div class="div-class">text</div>'
         );
     });
@@ -19,7 +19,7 @@ describe('htmlTag', () => {
             fallbackText: content,
         };
 
-        expect(newHtmlAnchorTag(url, config, content)).toEqual(
+        expect(newHtmlAnchorTag(url, config, content)).toStrictEqual(
             `<a href="${url}" target="${config.target}" rel="${config.rel}" class="${config.className.anchor_link}">${content}</a>`
         );
     });
@@ -33,7 +33,7 @@ describe('htmlTag', () => {
             fallbackText: 'fallbackText',
         };
 
-        expect(newHtmlAnchorTag(url, config)).toEqual(
+        expect(newHtmlAnchorTag(url, config)).toStrictEqual(
             `<a href="${url}" target="${config.target}" rel="${config.rel}">${config.fallbackText}</a>`
         );
     });
@@ -59,7 +59,7 @@ describe('htmlTag', () => {
             loading: 'lazy',
         };
 
-        expect(newHtmlImgTag(url, alt, config)).toEqual(
+        expect(newHtmlImgTag(url, alt, config)).toStrictEqual(
             `<img src="${url}" alt="${alt}" class="${config.className.image}" loading="${config.loading}">`
         );
     });
@@ -71,7 +71,7 @@ describe('htmlTag', () => {
             loading: 'eager',
         };
 
-        expect(newHtmlImgTag(url, alt, config)).toEqual(
+        expect(newHtmlImgTag(url, alt, config)).toStrictEqual(
             `<img src="${url}" alt="${alt}" loading="${config.loading}">`
         );
     });
@@ -84,7 +84,7 @@ describe('htmlTag', () => {
             loading: 'none',
         };
 
-        expect(newHtmlImgTag(url, alt, config)).toEqual(
+        expect(newHtmlImgTag(url, alt, config)).toStrictEqual(
             `<img src="${url}" alt="${alt}" class="${config.className.image}">`
         );
     });

--- a/test/opengraph.test.js
+++ b/test/opengraph.test.js
@@ -6,96 +6,96 @@ describe('opengraph', () => {
     it('Has a valid value at OpenGraphTitle', () => {
         const ogp = { ogTitle: 'test_title' };
 
-        expect(getOgTitle(ogp)).toEqual({ valid: true, title: 'test_title' });
+        expect(getOgTitle(ogp)).toStrictEqual({ valid: true, title: 'test_title' });
     });
 
     it('Not contains a value of OpenGraphTitle', () => {
         const ogp = {};
 
-        expect(getOgTitle(ogp)).toEqual({ valid: false, title: '' });
+        expect(getOgTitle(ogp)).toStrictEqual({ valid: false, title: '' });
     });
 
     it('Has a empty value at OpenGraphTitle', () => {
         const ogp = { ogTitle: '' };
 
-        expect(getOgTitle(ogp)).toEqual({ valid: false, title: '' });
+        expect(getOgTitle(ogp)).toStrictEqual({ valid: false, title: '' });
     });
 
     it('Has a invalid value at OpenGraphTitle', () => {
         const ogp = { ogTitle: 1000 };
 
-        expect(getOgTitle(ogp)).toEqual({ valid: false, title: '' });
+        expect(getOgTitle(ogp)).toStrictEqual({ valid: false, title: '' });
     });
 
     it('Has a valid value at OpenGraphDescription', () => {
         const ogp = { ogDescription: 'test_description' };
 
-        expect(getOgDescription(ogp, 140)).toEqual({ valid: true, description: 'test_description' });
+        expect(getOgDescription(ogp, 140)).toStrictEqual({ valid: true, description: 'test_description' });
     });
 
     it('Has a valid english sentence which is over max length at OpenGraphDescription', () => {
         const ogp = { ogDescription: 'test_description' };
 
-        expect(getOgDescription(ogp, 4)).toEqual({ valid: true, description: 'test...' });
+        expect(getOgDescription(ogp, 4)).toStrictEqual({ valid: true, description: 'test...' });
     });
 
     it('Has a valid japanese sentence which is over max length at OpenGraphDescription', () => {
         const ogp = { ogDescription: '👨🏻‍💻󠁧󠁢󠁥󠁮󠁧󠁿テストの🇯🇵ですくりぷしょん🍎を書きました。' };
 
-        expect(getOgDescription(ogp, 15)).toEqual({ valid: true, description: '👨🏻‍💻󠁧󠁢󠁥󠁮󠁧󠁿テストの🇯🇵ですくりぷしょん🍎...' });
+        expect(getOgDescription(ogp, 15)).toStrictEqual({ valid: true, description: '👨🏻‍💻󠁧󠁢󠁥󠁮󠁧󠁿テストの🇯🇵ですくりぷしょん🍎...' });
     });
 
     it('Not contains a value of OpenGraphDescription', () => {
         const ogp = {};
 
-        expect(getOgDescription(ogp, 140)).toEqual({ valid: false, description: '' });
+        expect(getOgDescription(ogp, 140)).toStrictEqual({ valid: false, description: '' });
     });
 
     it('Has a empty value at OpenGraphDescription', () => {
         const ogp = { ogDescription: '' };
 
-        expect(getOgDescription(ogp, 140)).toEqual({ valid: false, description: '' });
+        expect(getOgDescription(ogp, 140)).toStrictEqual({ valid: false, description: '' });
     });
 
     it('Has a invalid value at OpenGraphDescription', () => {
         const ogp = { ogDescription: 1234 };
 
-        expect(getOgDescription(ogp, 140)).toEqual({ valid: false, description: '' });
+        expect(getOgDescription(ogp, 140)).toStrictEqual({ valid: false, description: '' });
     });
 
     it('Has a value at OpenGraphImage', () => {
         const ogp = { ogImage: [{ url: 'test.png' }] };
 
-        expect(getOgImage(ogp)).toEqual({ valid: true, image: 'test.png' });
+        expect(getOgImage(ogp)).toStrictEqual({ valid: true, image: 'test.png' });
     });
 
     it('Has a empty value at OpenGraphImage', () => {
         const ogp = { ogImage: [{ url: '' }] };
 
-        expect(getOgImage(ogp)).toEqual({ valid: false, image: '' });
+        expect(getOgImage(ogp)).toStrictEqual({ valid: false, image: '' });
     });
 
     it('Has a invalid value at OpenGraphImage', () => {
         const ogp = { ogImage: [{ url: 1234 }] };
 
-        expect(getOgImage(ogp)).toEqual({ valid: false, image: '' });
+        expect(getOgImage(ogp)).toStrictEqual({ valid: false, image: '' });
     });
 
     it('Has a value at OpenGraphImage (selectIndex is larger than length)', () => {
         const ogp = { ogImage: [{ url: 'test.png' }] };
 
-        expect(getOgImage(ogp, 2)).toEqual({ valid: true, image: 'test.png' });
+        expect(getOgImage(ogp, 2)).toStrictEqual({ valid: true, image: 'test.png' });
     });
 
     it('Not contains a value of OpenGraphImage', () => {
         const ogp = {};
 
-        expect(getOgImage(ogp)).toEqual({ valid: false, image: '' });
+        expect(getOgImage(ogp)).toStrictEqual({ valid: false, image: '' });
     });
 
     it('Not contains a url value in OpenGraphImage', () => {
         const ogp = { ogImage: [{ width: 1200 }] };
 
-        expect(getOgImage(ogp)).toEqual({ valid: false, image: '' });
+        expect(getOgImage(ogp)).toStrictEqual({ valid: false, image: '' });
     });
 });

--- a/test/parameters.test.js
+++ b/test/parameters.test.js
@@ -9,27 +9,25 @@ describe('parameters', () => {
         const config = { class_name: { anchor_link: 'link-preview' }, descriptionLength: 140, disguise_crawler: true };
         const { class_name: className, description_length: descriptionLength } = config;
 
-        expect(getParameters(args, fallbackText, config)).toEqual(
-            {
-                scrape: {
-                    url: args[0],
-                    fetchOptions: {
-                        headers: {
-                            'accept': 'text/html',
-                            'user-agent': 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Chrome/112.0.0.0 Safari/537.36',
-                        },
+        expect(getParameters(args, fallbackText, config)).toStrictEqual({
+            scrape: {
+                url: args[0],
+                fetchOptions: {
+                    headers: {
+                        'accept': 'text/html',
+                        'user-agent': 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Chrome/112.0.0.0 Safari/537.36',
                     },
                 },
-                generate: {
-                    target: args[1],
-                    rel: args[2].replace('rel:', ''),
-                    loading: args[3].replace('loading:', ''),
-                    descriptionLength,
-                    className,
-                    fallbackText,
-                },
-            }
-        );
+            },
+            generate: {
+                target: args[1],
+                rel: args[2].replace('rel:', ''),
+                loading: args[3].replace('loading:', ''),
+                descriptionLength,
+                className,
+                fallbackText,
+            },
+        });
     });
 
     it('Specify first argument only', () => {
@@ -38,20 +36,18 @@ describe('parameters', () => {
         const config = { class_name: { anchor_link: 'link-preview' }, descriptionLength: 140, disguise_crawler: true };
         const { class_name: className, description_length: descriptionLength } = config;
 
-        expect(getParameters(args, fallbackText, config)).toEqual(
-            {
-                scrape: {
-                    url: args[0],
-                    fetchOptions: {
-                        headers: {
-                            'accept': 'text/html',
-                            'user-agent': 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Chrome/112.0.0.0 Safari/537.36',
-                        },
+        expect(getParameters(args, fallbackText, config)).toStrictEqual({
+            scrape: {
+                url: args[0],
+                fetchOptions: {
+                    headers: {
+                        'accept': 'text/html',
+                        'user-agent': 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Chrome/112.0.0.0 Safari/537.36',
                     },
                 },
-                generate: { target: '_blank', rel: 'nofollow', loading: 'lazy', descriptionLength, className, fallbackText },
-            }
-        );
+            },
+            generate: { target: '_blank', rel: 'nofollow', loading: 'lazy', descriptionLength, className, fallbackText },
+        });
     });
 
     it('Specify first argument only and set disguise_crawler of config to false', () => {
@@ -60,12 +56,10 @@ describe('parameters', () => {
         const config = { class_name: { anchor_link: 'link-preview' }, descriptionLength: 140, disguise_crawler: false };
         const { class_name: className, description_length: descriptionLength } = config;
 
-        expect(getParameters(args, fallbackText, config)).toEqual(
-            {
-                scrape: { url: args[0], fetchOptions: { headers: { accept: 'text/html' } } },
-                generate: { target: '_blank', rel: 'nofollow', loading: 'lazy', descriptionLength, className, fallbackText },
-            }
-        );
+        expect(getParameters(args, fallbackText, config)).toStrictEqual({
+            scrape: { url: args[0], fetchOptions: { headers: { accept: 'text/html' } } },
+            generate: { target: '_blank', rel: 'nofollow', loading: 'lazy', descriptionLength, className, fallbackText },
+        });
     });
 
     it('Specify nothing arguments', () => {

--- a/test/strings.test.js
+++ b/test/strings.test.js
@@ -4,7 +4,7 @@ const { stringLength, stringSlice } = require('../lib/strings');
 
 describe('common', () => {
     it('Calculate a length of string', () => {
-        expect(stringLength('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎')).toEqual(14);
+        expect(stringLength('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎')).toStrictEqual(14);
     });
 
     it('Cannot calculate a length of except for string', () => {
@@ -12,7 +12,7 @@ describe('common', () => {
     });
 
     it('Slice a string', () => {
-        expect(stringSlice('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎', 0, 3)).toEqual('aBあ');
+        expect(stringSlice('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎', 0, 3)).toStrictEqual('aBあ');
     });
 
     it('Cannot slice a value except for string', () => {
@@ -20,22 +20,22 @@ describe('common', () => {
     });
 
     it('Slice a string (start is not number type)', () => {
-        expect(stringSlice('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎', 'hoge', 5)).toEqual('aBあア亞');
+        expect(stringSlice('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎', 'hoge', 5)).toStrictEqual('aBあア亞');
     });
 
     it('Slice a string (start is smaller than zero)', () => {
-        expect(stringSlice('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎', -5, 13)).toEqual('%+👨🏻‍💻🇯🇵');
+        expect(stringSlice('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎', -5, 13)).toStrictEqual('%+👨🏻‍💻🇯🇵');
     });
 
     it('Slice a string (end calculate automatically)', () => {
-        expect(stringSlice('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎', 7)).toEqual('19%+👨🏻‍💻🇯🇵🍎');
+        expect(stringSlice('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎', 7)).toStrictEqual('19%+👨🏻‍💻🇯🇵🍎');
     });
 
     it('Slice a string (end is smaller than zero)', () => {
-        expect(stringSlice('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎', 7, -4)).toEqual('19%');
+        expect(stringSlice('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎', 7, -4)).toStrictEqual('19%');
     });
 
     it('Slice a string (end is smaller than start)', () => {
-        expect(stringSlice('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎', -1, -2)).toEqual('');
+        expect(stringSlice('aBあア亞　 19%+👨🏻‍💻🇯🇵🍎', -1, -2)).toStrictEqual('');
     });
 });


### PR DESCRIPTION
### Description

convert to fallback text link if open-graph-scraper occurred error.

### Relations

#14

### References



### Others
