### PR TITLE
接尾辞で個別のクラス名を付与できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm install hexo-tag-ogp-link-preview
 
 Write like below to your hexo article markdown file:
 ```
-{% link_preview url [target] [rel] [loading] %}
+{% link_preview url [target] [rel] [loading] [classSuffix] %}
 [Content]
 {% endlink_preview %}
 ```
@@ -20,21 +20,24 @@ Write like below to your hexo article markdown file:
 or you are able to use "Named Parameter":
 
 ```
-{% link_preview url [rel:{rel_value}] [target:{target_value}] [loading:{loading_value}] %}
+{% link_preview url [rel:{rel_value}] [target:{target_value}] [loading:{loading_value}] [classSuffix:{classSuffix_value}] %}
 [Content]
 {% endlink_preview %}
 ```
 
 ### Tag arguments
 
-Notice: All optionally parameters (except for the required `url` parameter) are able to use "Named Parameter".
+> [!NOTE]  
+> All optionally parameters (except for the required `url` parameter) are able to use "Named Parameter".
+  
 
-| Name      | Required? | Default    | Description                                                                                                                                                    |
-|-----------|-----------|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `url`     | Yes       |            | This parameter is a target of the link preview.                                                                                                                |
-| `target`  | No        | `_blank`   | Specify a `target` attribute of the anchor element.<br>One of `_self`, `_blank`, `_parent`, or `_top`.                                                         |
-| `rel`     | No        | `nofollow` | Specify a `rel` attribute of the anchor element.<br>One of `external`, `nofollow`, `noopener`, `noreferrer`, or `opener`.                                      |
-| `loading` | No        | `lazy`     | Specify a `loading` attribute of the image element.<br>One of `lazy`, `eager`, or `none`.<br>If specify a `none`, remove loading attribute from image element. |
+| Name          | Required? | Default    | Description                                                                                                                                                    |
+|---------------|-----------|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `url`         | Yes       |            | This parameter is a target of the link preview.                                                                                                                |
+| `target`      | No        | `_blank`   | Specify a `target` attribute of the anchor element.<br>One of `_self`, `_blank`, `_parent`, or `_top`.                                                         |
+| `rel`         | No        | `nofollow` | Specify a `rel` attribute of the anchor element.<br>One of `external`, `nofollow`, `noopener`, `noreferrer`, or `opener`.                                      |
+| `loading`     | No        | `lazy`     | Specify a `loading` attribute of the image element.<br>One of `lazy`, `eager`, or `none`.<br>If specify a `none`, remove loading attribute from image element. |
+| `classSuffix` | No        |            | Specify a suffix of `class` attribute value all of the div elements.                                                                                           |
 
 ### Tag content
 
@@ -55,7 +58,9 @@ link_preview:
 
 ### Setting values
 
-Notice: All setting values are NOT required.
+> [!Note]  
+> All setting values are NOT required.
+  
 
 | Name                       | type                 | Default        | Description                                                                                                                                                                                    |
 |----------------------------|----------------------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -70,25 +75,25 @@ Notice: All setting values are NOT required.
 Write a following to your hexo article markdown file:
 
 ```markdown
-{% link_preview http://www.example.com/ loading:lazy %}
+{% link_preview https://www.example.com/ loading:lazy classSuffix:special %}
 fallback Text
 {% endlink_preview %}
 ```
 
 When scraper get OpenGraph successfully, generated html like blow:
 ```html
-<a href="http://www.example.com/" target="_blank" rel="nofollow" class="link-preview">
-    <div class="og-image">
+<a href="https://www.example.com/" target="_blank" rel="nofollow" class="link-preview">
+    <div class="og-image-special">
         <img src="https://www.example.com/image.png" alt="example image" class="not-gallery-item" loading="lazy">
     </div>
-    <div class="descriptions">
-        <div class="og-title">title text</div>
-        <div class="og-description">description text</div>
+    <div class="descriptions-special">
+        <div class="og-title-special">title text</div>
+        <div class="og-description-special">description text</div>
     </div>
 </a>
 ```
 
 When scraper fail to get OpenGraph, generated html like blow:
 ```html
-<a href="http://www.example.com/">fallback Text</a>
+<a href="https://www.example.com/" target="_blank" rel="nofollow">fallback Text</a>
 ```

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,13 +43,7 @@ export default defineConfig([
             '@stylistic/indent': ['error', 4, {
                 SwitchCase: 1,
             }],
-            '@stylistic/comma-dangle': ['error', {
-                arrays: 'always-multiline',
-                objects: 'always-multiline',
-                imports: 'always-multiline',
-                exports: 'always-multiline',
-                functions: 'never',
-            }],
+            '@stylistic/comma-dangle': ['error', 'always-multiline'],
             '@stylistic/object-curly-spacing': ['error', 'always', {
                 objectsInObjects: true,
             }],

--- a/index.js
+++ b/index.js
@@ -19,5 +19,5 @@ hexo.extend.tag.register(
     {
         async: true,
         ends: true,
-    }
+    },
 );

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -7,14 +7,14 @@ function newContent(escapedTitle, escapedDesc, ogImage, generate) {
     const content = [];
 
     if (ogImage.valid) {
-        content.push(newHtmlDivTag('og-image', newHtmlImgTag(ogImage.image, '', generate)));
+        content.push(newHtmlDivTag('og-image', newHtmlImgTag(ogImage.image, '', generate), generate));
     }
 
     const descriptions = [
-        newHtmlDivTag('og-title', escapedTitle),
-        newHtmlDivTag('og-description', escapedDesc),
+        newHtmlDivTag('og-title', escapedTitle, generate),
+        newHtmlDivTag('og-description', escapedDesc, generate),
     ];
-    content.push(newHtmlDivTag('descriptions', descriptions.join('')));
+    content.push(newHtmlDivTag('descriptions', descriptions.join(''), generate));
 
     return content.join('');
 }

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -33,7 +33,7 @@ module.exports = (scraper, params) => {
             return newHtmlAnchorTag(
                 params.scrape.url,
                 params.generate,
-                newContent(title, description, getOgImage(ogp), params.generate)
+                newContent(title, description, getOgImage(ogp), params.generate),
             );
         })
         .catch((error) => {

--- a/lib/htmltag.js
+++ b/lib/htmltag.js
@@ -3,8 +3,13 @@
 const util = require('hexo-util');
 const { hasTypeOfProperty } = require('./common');
 
-function newHtmlDivTag(className, content) {
-    return util.htmlTag('div', { class: className }, content, false);
+function newHtmlDivTag(className, content, config) {
+    return util.htmlTag(
+        'div',
+        { class: [className, config.classSuffix].filter((value) => value).join('-') },
+        content,
+        false
+    );
 }
 
 function newHtmlAnchorTag(url, config, content) {

--- a/lib/htmltag.js
+++ b/lib/htmltag.js
@@ -8,7 +8,7 @@ function newHtmlDivTag(className, content, config) {
         'div',
         { class: [className, config.classSuffix].filter((value) => value).join('-') },
         content,
-        false
+        false,
     );
 }
 

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -17,8 +17,13 @@ function parseArgs(args) {
     const target = parseOptionalKeywordArg(opts, { argName: 'target:', index: 0 }, targetKeywords);
     const rel = parseOptionalKeywordArg(opts, { argName: 'rel:', index: 1 }, relKeywords);
     const loading = parseOptionalKeywordArg(opts, { argName: 'loading:', index: 2 }, loadingKeywords);
+    const classSuffix = parseOptionalArg(opts, { argName: 'classSuffix:', index: 3 });
 
-    return { url, target, rel, loading };
+    return { url, target, rel, loading, classSuffix };
+}
+
+function parseOptionalArg(opts, find, defaultWord = '') {
+    return findOptionalArgs(opts, find).shift() || defaultWord;
 }
 
 function parseOptionalKeywordArg(opts, find, keywords, defaultIndex = 0) {
@@ -46,12 +51,12 @@ function getFetchOptions(isCrawler) {
 }
 
 module.exports = (args, content, config) => {
-    const { url, target, rel, loading } = parseArgs(args);
+    const { url, target, rel, loading, classSuffix } = parseArgs(args);
     const { class_name: className, description_length: descriptionLength, disguise_crawler: isCrawler } = config;
     const fetchOptions = getFetchOptions(isCrawler);
 
     return {
         scrape: { url, fetchOptions },
-        generate: { target, rel, loading, descriptionLength, className, fallbackText: content },
+        generate: { target, rel, loading, classSuffix, descriptionLength, className, fallbackText: content },
     };
 };

--- a/test/generator.test.js
+++ b/test/generator.test.js
@@ -10,6 +10,31 @@ describe('generator', () => {
     it('Was able to get all values from OpenGraph', async () => {
         const { scraper, imageUrl, title, description } = mockFullOgValues();
         const params = getParameters(
+            ['https://example.com'],
+            'fallbackText',
+            getConfig({
+                link_preview: {
+                    class_name: { anchor_link: 'link-preview' },
+                    description_length: 140,
+                    disguise_crawler: true,
+                },
+            }),
+        );
+
+        await expect(generate(scraper, params)).resolves.toStrictEqual([
+            '<a href="https://example.com/" target="_blank" rel="nofollow" class="link-preview">',
+            `<div class="og-image"><img src="${imageUrl}" alt="" loading="lazy"></div>`,
+            '<div class="descriptions">',
+            '<div class="og-title">' + title + '</div>',
+            '<div class="og-description">' + description + '</div>',
+            '</div>',
+            '</a>',
+        ].join(''));
+    });
+
+    it('Was able to get all values from OpenGraph and append class suffix', async () => {
+        const { scraper, imageUrl, title, description } = mockFullOgValues();
+        const params = getParameters(
             ['https://example.com', 'classSuffix:suffix'],
             'fallbackText',
             getConfig({
@@ -33,6 +58,30 @@ describe('generator', () => {
     });
 
     it('Was able to get title and description from OpenGraph', async () => {
+        const { scraper, title, description } = mockTextOgValues();
+        const params = getParameters(
+            ['https://example.com'],
+            'fallbackText',
+            getConfig({
+                link_preview: {
+                    class_name: { anchor_link: 'link-preview' },
+                    description_length: 140,
+                    disguise_crawler: true,
+                },
+            }),
+        );
+
+        await expect(generate(scraper, params)).resolves.toStrictEqual([
+            '<a href="https://example.com/" target="_blank" rel="nofollow" class="link-preview">',
+            '<div class="descriptions">',
+            '<div class="og-title">' + title + '</div>',
+            '<div class="og-description">' + description + '</div>',
+            '</div>',
+            '</a>',
+        ].join(''));
+    });
+
+    it('Was able to get title and description from OpenGraph and append class suffix', async () => {
         const { scraper, title, description } = mockTextOgValues();
         const params = getParameters(
             ['https://example.com', 'classSuffix:suffix'],

--- a/test/generator.test.js
+++ b/test/generator.test.js
@@ -2,7 +2,6 @@
 
 const getConfig = require('../lib/configure');
 const generate = require('../lib/generator');
-const { newHtmlAnchorTag, newHtmlDivTag, newHtmlImgTag } = require('../lib/htmltag');
 const getParameters = require('../lib/parameters');
 
 const { mockFullOgValues, mockTextOgValues, mockInvalidOgValues, mockThrowError } = require('./mock/scraper');
@@ -11,7 +10,7 @@ describe('generator', () => {
     it('Was able to get all values from OpenGraph', async () => {
         const { scraper, imageUrl, title, description } = mockFullOgValues();
         const params = getParameters(
-            ['https://example.com', '_blank', 'nofollow'],
+            ['https://example.com', 'classSuffix:suffix'],
             'fallbackText',
             getConfig({
                 link_preview: {
@@ -22,21 +21,21 @@ describe('generator', () => {
             })
         );
 
-        await expect(generate(scraper, params)).resolves.toStrictEqual(newHtmlAnchorTag(
-            params.scrape.url,
-            params.generate,
-            newHtmlDivTag('og-image', newHtmlImgTag(imageUrl, '', params.generate))
-            + newHtmlDivTag(
-                'descriptions',
-                newHtmlDivTag('og-title', title) + newHtmlDivTag('og-description', description)
-            )
-        ));
+        await expect(generate(scraper, params)).resolves.toStrictEqual([
+            '<a href="https://example.com/" target="_blank" rel="nofollow" class="link-preview">',
+            `<div class="og-image-suffix"><img src="${imageUrl}" alt="" loading="lazy"></div>`,
+            '<div class="descriptions-suffix">',
+            '<div class="og-title-suffix">' + title + '</div>',
+            '<div class="og-description-suffix">' + description + '</div>',
+            '</div>',
+            '</a>',
+        ].join(''));
     });
 
     it('Was able to get title and description from OpenGraph', async () => {
         const { scraper, title, description } = mockTextOgValues();
         const params = getParameters(
-            ['https://example.com', '_blank', 'nofollow'],
+            ['https://example.com', 'classSuffix:suffix'],
             'fallbackText',
             getConfig({
                 link_preview: {
@@ -47,20 +46,20 @@ describe('generator', () => {
             })
         );
 
-        await expect(generate(scraper, params)).resolves.toEqual(newHtmlAnchorTag(
-            params.scrape.url,
-            params.generate,
-            newHtmlDivTag(
-                'descriptions',
-                newHtmlDivTag('og-title', title) + newHtmlDivTag('og-description', description)
-            )
-        ));
+        await expect(generate(scraper, params)).resolves.toStrictEqual([
+            '<a href="https://example.com/" target="_blank" rel="nofollow" class="link-preview">',
+            '<div class="descriptions-suffix">',
+            '<div class="og-title-suffix">' + title + '</div>',
+            '<div class="og-description-suffix">' + description + '</div>',
+            '</div>',
+            '</a>',
+        ].join(''));
     });
 
     it('Neither able to get title nor description from OpenGraph', async () => {
         const { scraper } = mockInvalidOgValues();
         const params = getParameters(
-            ['https://example.com', '_blank', 'nofollow'],
+            ['https://example.com'],
             'fallbackText',
             getConfig({
                 link_preview: {
@@ -72,14 +71,14 @@ describe('generator', () => {
         );
 
         await expect(generate(scraper, params)).resolves.toStrictEqual(
-            newHtmlAnchorTag(params.scrape.url, params.generate)
+            `<a href="${params.scrape.url}/" target="_blank" rel="nofollow">${params.generate.fallbackText}</a>`
         );
     });
 
     it('Throw error from OpenGraph scraper', async () => {
         const { scraper } = mockThrowError();
         const params = getParameters(
-            ['https://example.com', '_blank', 'nofollow'],
+            ['https://example.com'],
             'fallbackText',
             getConfig({
                 link_preview: {
@@ -91,7 +90,7 @@ describe('generator', () => {
         );
 
         await expect(generate(scraper, params)).resolves.toStrictEqual(
-            newHtmlAnchorTag(params.scrape.url, params.generate)
+            `<a href="${params.scrape.url}/" target="_blank" rel="nofollow">${params.generate.fallbackText}</a>`
         );
     });
 });

--- a/test/generator.test.js
+++ b/test/generator.test.js
@@ -18,7 +18,7 @@ describe('generator', () => {
                     description_length: 140,
                     disguise_crawler: true,
                 },
-            })
+            }),
         );
 
         await expect(generate(scraper, params)).resolves.toStrictEqual([
@@ -43,7 +43,7 @@ describe('generator', () => {
                     description_length: 140,
                     disguise_crawler: true,
                 },
-            })
+            }),
         );
 
         await expect(generate(scraper, params)).resolves.toStrictEqual([
@@ -67,11 +67,11 @@ describe('generator', () => {
                     description_length: 140,
                     disguise_crawler: true,
                 },
-            })
+            }),
         );
 
         await expect(generate(scraper, params)).resolves.toStrictEqual(
-            `<a href="${params.scrape.url}/" target="_blank" rel="nofollow">${params.generate.fallbackText}</a>`
+            `<a href="${params.scrape.url}/" target="_blank" rel="nofollow">${params.generate.fallbackText}</a>`,
         );
     });
 
@@ -86,11 +86,11 @@ describe('generator', () => {
                     description_length: 140,
                     disguise_crawler: true,
                 },
-            })
+            }),
         );
 
         await expect(generate(scraper, params)).resolves.toStrictEqual(
-            `<a href="${params.scrape.url}/" target="_blank" rel="nofollow">${params.generate.fallbackText}</a>`
+            `<a href="${params.scrape.url}/" target="_blank" rel="nofollow">${params.generate.fallbackText}</a>`,
         );
     });
 });

--- a/test/htmltag.test.js
+++ b/test/htmltag.test.js
@@ -8,7 +8,7 @@ describe('htmlTag', () => {
         expect(newHtmlDivTag('div-class', 'text', {})).toStrictEqual(util.htmlTag(
             'div',
             { class: 'div-class' },
-            'text'
+            'text',
         ));
     });
 
@@ -16,7 +16,7 @@ describe('htmlTag', () => {
         expect(newHtmlDivTag('div-class', 'text', { classSuffix: 'suffix' })).toStrictEqual(util.htmlTag(
             'div',
             { class: 'div-class-suffix' },
-            'text'
+            'text',
         ));
     });
 
@@ -34,7 +34,7 @@ describe('htmlTag', () => {
         expect(newHtmlAnchorTag(href, config, content)).toStrictEqual(util.htmlTag(
             'a',
             { href, target: config.target, rel: config.rel, class: config.className.anchor_link },
-            content
+            content,
         ));
     });
 
@@ -50,7 +50,7 @@ describe('htmlTag', () => {
         expect(newHtmlAnchorTag(href, config)).toStrictEqual(util.htmlTag(
             'a',
             { href, target: config.target, rel: config.rel },
-            config.fallbackText
+            config.fallbackText,
         ));
     });
 
@@ -63,7 +63,7 @@ describe('htmlTag', () => {
         };
 
         expect(() => newHtmlAnchorTag(url, config)).toThrow(
-            new Error('failed to generate a new anchor tag.')
+            new Error('failed to generate a new anchor tag.'),
         );
     });
 
@@ -78,7 +78,7 @@ describe('htmlTag', () => {
 
         expect(newHtmlImgTag(src, alt, config)).toStrictEqual(util.htmlTag(
             'img',
-            { src, alt, class: config.className.image, loading: config.loading }
+            { src, alt, class: config.className.image, loading: config.loading },
         ));
     });
 
@@ -91,7 +91,7 @@ describe('htmlTag', () => {
 
         expect(newHtmlImgTag(src, alt, config)).toStrictEqual(util.htmlTag(
             'img',
-            { src, alt, loading: config.loading }
+            { src, alt, loading: config.loading },
         ));
     });
 
@@ -105,7 +105,7 @@ describe('htmlTag', () => {
 
         expect(newHtmlImgTag(src, alt, config)).toStrictEqual(util.htmlTag(
             'img',
-            { src, alt, class: config.className.image }
+            { src, alt, class: config.className.image },
         ));
     });
 });

--- a/test/htmltag.test.js
+++ b/test/htmltag.test.js
@@ -1,31 +1,45 @@
 'use strict';
 
+const util = require('hexo-util');
 const { newHtmlDivTag, newHtmlAnchorTag, newHtmlImgTag } = require('../lib/htmltag');
 
 describe('htmlTag', () => {
     it('Generate a new html div tag', () => {
-        expect(newHtmlDivTag('div-class', 'text')).toStrictEqual(
-            '<div class="div-class">text</div>'
-        );
+        expect(newHtmlDivTag('div-class', 'text', {})).toStrictEqual(util.htmlTag(
+            'div',
+            { class: 'div-class' },
+            'text'
+        ));
+    });
+
+    it('Generate a new html div tag with class name suffix', () => {
+        expect(newHtmlDivTag('div-class', 'text', { classSuffix: 'suffix' })).toStrictEqual(util.htmlTag(
+            'div',
+            { class: 'div-class-suffix' },
+            'text'
+        ));
     });
 
     it('Generate a new html anchor tag', () => {
-        const url = 'http://example.com/';
+        const href = 'https://example.com/';
         const content = 'text';
         const config = {
             target: '_blank',
             rel: 'nofollow',
+            classSuffix: 'suffix',
             className: { anchor_link: 'anchor-class' },
             fallbackText: content,
         };
 
-        expect(newHtmlAnchorTag(url, config, content)).toStrictEqual(
-            `<a href="${url}" target="${config.target}" rel="${config.rel}" class="${config.className.anchor_link}">${content}</a>`
-        );
+        expect(newHtmlAnchorTag(href, config, content)).toStrictEqual(util.htmlTag(
+            'a',
+            { href, target: config.target, rel: config.rel, class: config.className.anchor_link },
+            content
+        ));
     });
 
     it('Generate a new html anchor tag with fallbackText', () => {
-        const url = 'http://example.com/';
+        const href = 'https://example.com/';
         const config = {
             target: '_blank',
             rel: 'nofollow',
@@ -33,13 +47,15 @@ describe('htmlTag', () => {
             fallbackText: 'fallbackText',
         };
 
-        expect(newHtmlAnchorTag(url, config)).toStrictEqual(
-            `<a href="${url}" target="${config.target}" rel="${config.rel}">${config.fallbackText}</a>`
-        );
+        expect(newHtmlAnchorTag(href, config)).toStrictEqual(util.htmlTag(
+            'a',
+            { href, target: config.target, rel: config.rel },
+            config.fallbackText
+        ));
     });
 
     it('Failed to generate a new html anchor tag', () => {
-        const url = 'http://example.com/';
+        const url = 'https://example.com/';
         const config = {
             target: '_blank',
             rel: 'nofollow',
@@ -52,40 +68,44 @@ describe('htmlTag', () => {
     });
 
     it('Generate a new html image tag', () => {
-        const url = 'http://example.com/';
+        const src = 'https://example.com/';
         const alt = 'alternative text';
         const config = {
-            className: { image: 'image-class' },
             loading: 'lazy',
+            classSuffix: 'suffix',
+            className: { image: 'image-class' },
         };
 
-        expect(newHtmlImgTag(url, alt, config)).toStrictEqual(
-            `<img src="${url}" alt="${alt}" class="${config.className.image}" loading="${config.loading}">`
-        );
+        expect(newHtmlImgTag(src, alt, config)).toStrictEqual(util.htmlTag(
+            'img',
+            { src, alt, class: config.className.image, loading: config.loading }
+        ));
     });
 
     it('Generate a new html image tag without class name', () => {
-        const url = 'http://example.com/';
+        const src = 'https://example.com/';
         const alt = 'alternative text';
         const config = {
             loading: 'eager',
         };
 
-        expect(newHtmlImgTag(url, alt, config)).toStrictEqual(
-            `<img src="${url}" alt="${alt}" loading="${config.loading}">`
-        );
+        expect(newHtmlImgTag(src, alt, config)).toStrictEqual(util.htmlTag(
+            'img',
+            { src, alt, loading: config.loading }
+        ));
     });
 
     it('Generate a new html image tag without loading', () => {
-        const url = 'http://example.com/';
+        const src = 'https://example.com/';
         const alt = 'alternative text';
         const config = {
-            className: { image: 'image-class' },
             loading: 'none',
+            className: { image: 'image-class' },
         };
 
-        expect(newHtmlImgTag(url, alt, config)).toStrictEqual(
-            `<img src="${url}" alt="${alt}" class="${config.className.image}">`
-        );
+        expect(newHtmlImgTag(src, alt, config)).toStrictEqual(util.htmlTag(
+            'img',
+            { src, alt, class: config.className.image }
+        ));
     });
 });

--- a/test/parameters.test.js
+++ b/test/parameters.test.js
@@ -4,7 +4,7 @@ const getParameters = require('../lib/parameters');
 
 describe('parameters', () => {
     it('Specify all arguments explicitly', () => {
-        const args = ['https://example.com', '_self', 'rel:noopener', 'loading:eager'];
+        const args = ['https://example.com', '_self', 'rel:noopener', 'loading:eager', 'classSuffix:suffix'];
         const fallbackText = 'fallbackText';
         const config = { class_name: { anchor_link: 'link-preview' }, descriptionLength: 140, disguise_crawler: true };
         const { class_name: className, description_length: descriptionLength } = config;
@@ -23,6 +23,7 @@ describe('parameters', () => {
                 target: args[1],
                 rel: args[2].replace('rel:', ''),
                 loading: args[3].replace('loading:', ''),
+                classSuffix: args[4].replace('classSuffix:', ''),
                 descriptionLength,
                 className,
                 fallbackText,
@@ -46,7 +47,7 @@ describe('parameters', () => {
                     },
                 },
             },
-            generate: { target: '_blank', rel: 'nofollow', loading: 'lazy', descriptionLength, className, fallbackText },
+            generate: { target: '_blank', rel: 'nofollow', loading: 'lazy', classSuffix: '', descriptionLength, className, fallbackText },
         });
     });
 
@@ -58,7 +59,7 @@ describe('parameters', () => {
 
         expect(getParameters(args, fallbackText, config)).toStrictEqual({
             scrape: { url: args[0], fetchOptions: { headers: { accept: 'text/html' } } },
-            generate: { target: '_blank', rel: 'nofollow', loading: 'lazy', descriptionLength, className, fallbackText },
+            generate: { target: '_blank', rel: 'nofollow', loading: 'lazy', classSuffix: '', descriptionLength, className, fallbackText },
         });
     });
 

--- a/test/parameters.test.js
+++ b/test/parameters.test.js
@@ -68,7 +68,7 @@ describe('parameters', () => {
         const config = { class_name: { anchor_link: 'link-preview' }, descriptionLength: 140, disguise_crawler: true };
 
         expect(() => getParameters([], fallbackText, config)).toThrow(
-            new Error('Scraping target url is not contains.')
+            new Error('Scraping target url is not contains.'),
         );
     });
 
@@ -78,7 +78,7 @@ describe('parameters', () => {
         const config = { class_name: { anchor_link: 'link-preview' }, descriptionLength: 140, disguise_crawler: true };
 
         expect(() => getParameters(args, fallbackText, config)).toThrow(
-            new Error('Scraping target url is not contains.')
+            new Error('Scraping target url is not contains.'),
         );
     });
 });

--- a/test/parameters.test.js
+++ b/test/parameters.test.js
@@ -3,8 +3,8 @@
 const getParameters = require('../lib/parameters');
 
 describe('parameters', () => {
-    it('Specify all arguments explicitly', () => {
-        const args = ['https://example.com', '_self', 'rel:noopener', 'loading:eager', 'classSuffix:suffix'];
+    it('Specify all arguments explicitly (without any named parameters)', () => {
+        const args = ['https://example.com', '_self', 'noopener', 'eager', 'suffix'];
         const fallbackText = 'fallbackText';
         const config = { class_name: { anchor_link: 'link-preview' }, descriptionLength: 140, disguise_crawler: true };
         const { class_name: className, description_length: descriptionLength } = config;
@@ -21,9 +21,65 @@ describe('parameters', () => {
             },
             generate: {
                 target: args[1],
-                rel: args[2].replace('rel:', ''),
+                rel: args[2],
+                loading: args[3],
+                classSuffix: args[4],
+                descriptionLength,
+                className,
+                fallbackText,
+            },
+        });
+    });
+
+    it('Specify all arguments explicitly (mix in all named parameters)', () => {
+        const args = ['https://example.com', 'classSuffix:suffix', 'target:_self', 'loading:eager', 'rel:noopener'];
+        const fallbackText = 'fallbackText';
+        const config = { class_name: { anchor_link: 'link-preview' }, descriptionLength: 140, disguise_crawler: true };
+        const { class_name: className, description_length: descriptionLength } = config;
+
+        expect(getParameters(args, fallbackText, config)).toStrictEqual({
+            scrape: {
+                url: args[0],
+                fetchOptions: {
+                    headers: {
+                        'accept': 'text/html',
+                        'user-agent': 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Chrome/112.0.0.0 Safari/537.36',
+                    },
+                },
+            },
+            generate: {
+                target: args[2].replace('target:', ''),
+                rel: args[4].replace('rel:', ''),
                 loading: args[3].replace('loading:', ''),
-                classSuffix: args[4].replace('classSuffix:', ''),
+                classSuffix: args[1].replace('classSuffix:', ''),
+                descriptionLength,
+                className,
+                fallbackText,
+            },
+        });
+    });
+
+    it('Specify all arguments explicitly (mix in some named parameters)', () => {
+        const args = ['https://example.com', '_self', 'classSuffix:suffix', 'eager', 'rel:noopener'];
+        const fallbackText = 'fallbackText';
+        const config = { class_name: { anchor_link: 'link-preview' }, descriptionLength: 140, disguise_crawler: true };
+        const { class_name: className, description_length: descriptionLength } = config;
+
+        expect(getParameters(args, fallbackText, config)).toStrictEqual({
+            scrape: {
+                url: args[0],
+                fetchOptions: {
+                    headers: {
+                        'accept': 'text/html',
+                        'user-agent': 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Chrome/112.0.0.0 Safari/537.36',
+                    },
+                },
+            },
+            generate: {
+                target: args[1],
+                rel: args[4].replace('rel:', ''),
+                loading: args[3],
+                classSuffix: args[2].replace('classSuffix:', ''),
                 descriptionLength,
                 className,
                 fallbackText,


### PR DESCRIPTION
### Description

The 'classSuffix' parameter is able to append suffix to a class attribute of all div elements.

### Relations

#12

### References



### Others
